### PR TITLE
fixed DEPRECATION WARNING

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,27 +1,27 @@
 Sunrise::Engine.routes.draw do
   root Sunrise::Config.root_route_options
-  
+
   get "/activities/p/:page", to: "activities#index", page: /\d+/
   get "/dashboard", to: "dashboard#index", as: :dashboard
-  
+
   resource :settings, only: [:edit, :update]
   resources :activities, only: [:index]
-  
+
   controller "manager" do
     scope ":model_name" do
-      get "/", to: :index, as: :index
-      get "/export.:format", to: :export, as: :export
-      post "/sort", to: :sort, as: :sort
-      get "/new", to: :new, as: :new
-      post "/new", to: :create, as: :create
-      delete "/mass_destroy", to: :mass_destroy, as: :mass_destroy
-      
+      get "/", action: :index, as: :index
+      get "/export.:format", action: :export, as: :export
+      post "/sort", action: :sort, as: :sort
+      get "/new", action: :new, as: :new
+      post "/new", action: :create, as: :create
+      delete "/mass_destroy", action: :mass_destroy, as: :mass_destroy
+
       scope ":id" do
-        get "/", to: :show, as: :show
-        get "/edit", to: :edit, as: :edit
-        patch "/edit", to: :update, as: :update
-        get "/delete", to: :delete, as: :delete
-        delete "/delete", to: :destroy, as: :destroy
+        get "/", action: :show, as: :show
+        get "/edit", action: :edit, as: :edit
+        patch "/edit", action: :update, as: :update
+        get "/delete", action: :delete, as: :delete
+        delete "/delete", action: :destroy, as: :destroy
       end
     end
   end


### PR DESCRIPTION
DEPRECATION WARNING: Defining a route where `to` is a symbol is deprecated. Please change `to: :action_name` to `action: :action_name`.