### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/sunrise-cms.gemspec
+++ b/sunrise-cms.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.description = 'Sunrise is a Open Source CMS'
   s.authors = ['Igor Galeta', 'Pavlo Galeta']
   s.email = 'galeta.igor@gmail.com'
-  s.rubyforge_project = 'sunrise-cms'
   s.homepage = 'https://github.com/galetahub/sunrise'
   s.license = 'MIT'
 


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436